### PR TITLE
edit grep option

### DIFF
--- a/Nextday/telegram.sh
+++ b/Nextday/telegram.sh
@@ -38,8 +38,8 @@ python3 ../spreadsheet_client.py |sed -e 's/],/\n/g' -e 's/]//g' -e 's/\[//g' -e
 python3 ../spreadsheet_member.py |sed -e 's/],/\n/g' -e 's/]//g' -e 's/\[//g' -e "s/'//g" -e "s/ //g" > member
 
 # duplication check
-cat client |awk -F',' '{print $1}' |sort |uniq -d | grep -P "\D" && exit 3
-cat member |awk -F',' '{print $1}' |sort |uniq -d | grep -P "\D" && exit 4
+cat client | awk -F',' '{print $1}' | sort | uniq -d | grep '[^0-9]' && exit 3
+cat member | awk -F',' '{print $1}' | sort | uniq -d | grep '[^0-9]' && exit 4
 
 while read line
 do

--- a/Today/telegram.sh
+++ b/Today/telegram.sh
@@ -38,8 +38,8 @@ python3 ../spreadsheet_client.py |sed -e 's/],/\n/g' -e 's/]//g' -e 's/\[//g' -e
 python3 ../spreadsheet_member.py |sed -e 's/],/\n/g' -e 's/]//g' -e 's/\[//g' -e "s/'//g" -e "s/ //g" > member
 
 # duplication check
-cat client |awk -F',' '{print $1}' |sort |uniq -d | grep -P "\D" && exit 3
-cat member |awk -F',' '{print $1}' |sort |uniq -d | grep -P "\D" && exit 4
+cat client | awk -F',' '{print $1}' | sort | uniq -d | grep '[^0-9]' && exit 3
+cat member | awk -F',' '{print $1}' | sort | uniq -d | grep '[^0-9]' && exit 4
 
 while read line
 do


### PR DESCRIPTION
Alpine Linux で利用可能なツールを用いて、指定されたコマンドを書き換えることができます。`grep -P` オプションの代わりに、基本的な正規表現または拡張正規表現を使用します。

`grep -P "\D"` は、数字以外の文字を含む行を検索するために使用されています。このパターンは、基本的な正規表現を使っても表現できます。数字以外の文字を検索するためには、`[^0-9]` というパターンを使用します。

したがって、コマンドは次のように書き換えられます：

```bash
cat client | awk -F',' '{print $1}' | sort | uniq -d | grep '[^0-9]' && exit 3
cat member | awk -F',' '{print $1}' | sort | uniq -d | grep '[^0-9]' && exit 4
```

この書き換えにより、`grep -P` を使わずに数字以外の文字を含む行を検索することができます。このコマンドは、Alpine Linux を含むほとんどの Unix/Linux ディストリビューションで動作します。