### PR TITLE
update

### DIFF
--- a/Nextday/telegram.sh
+++ b/Nextday/telegram.sh
@@ -11,8 +11,8 @@ test -d ./FILE || mkdir ./FILE
 test -d ./DSC || mkdir ./DSC
 
 # delete old dir
-rm -rf ./FILE/`date +%Y%m%d -d'30 day ago'`*
-rm -rf ./DSC/`date +%Y%m%d -d'30 day ago'`*
+rm -rf ./FILE/$(date -D %Y%m%d -d "$(date +%Y%m%d) - 30 days")*
+rm -rf ./DSC/$(date -D %Y%m%d -d "$(date +%Y%m%d) - 30 days")*
 
 FILE_DATE=`date +%Y%m%d%H%M`
 OLD_FILE_DATE=`ls -ltr ./FILE/ |tail -n1 |awk '{print $9}'`
@@ -22,8 +22,8 @@ python3 ../get_events.py | sed -e 's:<html-blob>::g' -e 's:</html-blob>::g' -e "
 sed -i -E 's@^.*(https?://[-A-Za-z0-9+&@#/%?=~_|!:,.;]*[-A-Za-z0-9+&@#/%=~_|]).*$@\1@' schedule.txt
 
 # make text
-sed -e "s/DATE/`date +%Y-%m-%d --date tomorrow`/" ../reverse.sed > make_reverse.sed
-sed -n "/`date +%Y-%m-%d --date tomorrow`/,/^$/p" schedule.txt  | sed -f make_reverse.sed | sed -e "s:`date +%Y-%m-%d --date tomorrow`:`date +%m/%d --date tomorrow`:" -e "s/~.*//" > make.txt
+sed -e "s/DATE/$(date -D %Y-%m-%d -d '$(date +%Y-%m-%d) + 1 days')/" ../reverse.sed > make_reverse.sed
+sed -n "/$(date -D %Y-%m-%d -d '$(date +%Y-%m-%d) + 1 days')/,/^$/p" schedule.txt | sed -f make_reverse.sed | sed -e "s:$(date -D %Y-%m-%d -d '$(date +%Y-%m-%d) + 1 days'):$(date -D %m/%d -d '$(date +%m/%d) + 1 days'):" -e "s/~.*//" > make.txt
 
 test -f make.txt.`date +%Y%m%d` && diff make.txt make.txt.`date +%Y%m%d` && exit 1
 test -f make.txt.`date +%Y%m%d` && diff make.txt make.txt.`date +%Y%m%d` | grep "<" || (cp -f make.txt make.txt.`date +%Y%m%d` && exit 2) 
@@ -105,12 +105,9 @@ echo ""
 
 done
 
-# rm -rf ./FILE/`date +%Y%m%d -d'30 day ago'`*
-# rm -rf ./DSC/`date +%Y%m%d -d'30 day ago'`*
-
 cp -f make.txt make.txt.`date +%Y%m%d`
 
-test -f make.txt.`date +%Y%m%d -d'1 day ago'` && rm -f make.txt.`date +%Y%m%d -d'1 day ago'`
+test -f make.txt.$(date -D %Y%m%d -d "$(date +%Y%m%d) - 1 days") && rm -f make.txt.$(date -D %Y%m%d -d "$(date +%Y%m%d) - 1 days")
 
 rm -f ./client
 rm -f ./member

--- a/Today/telegram.sh
+++ b/Today/telegram.sh
@@ -11,8 +11,8 @@ test -d ./FILE || mkdir ./FILE
 test -d ./DSC || mkdir ./DSC
 
 # delete old dir
-rm -rf ./FILE/`date +%Y%m%d -d'30 day ago'`*
-rm -rf ./DSC/`date +%Y%m%d -d'30 day ago'`*
+rm -rf ./FILE/$(date -D %Y%m%d -d "$(date +%Y%m%d) - 30 days")*
+rm -rf ./DSC/$(date -D %Y%m%d -d "$(date +%Y%m%d) - 30 days")*
 
 FILE_DATE=`date +%Y%m%d%H%M`
 OLD_FILE_DATE=`ls -ltr ./FILE/ |tail -n1 |awk '{print $9}'`
@@ -105,12 +105,9 @@ echo ""
 
 done
 
-# rm -rf ./FILE/`date +%Y%m%d -d'30 day ago'`*
-# rm -rf ./DSC/`date +%Y%m%d -d'30 day ago'`*
-
 cp -f make.txt make.txt.`date +%Y%m%d`
 
-test -f make.txt.`date +%Y%m%d -d'1 day ago'` && rm -f make.txt.`date +%Y%m%d -d'1 day ago'`
+test -f make.txt.$(date -D %Y%m%d -d "$(date +%Y%m%d) - 1 days") && rm -f make.txt.$(date -D %Y%m%d -d "$(date +%Y%m%d) - 1 days")
 
 rm -f ./client
 rm -f ./member


### PR DESCRIPTION
Alpine Linux では、`date` コマンドの `-d` オプションが利用できません。代わりに、`date` コマンドで日付計算を行うためには、`-D` オプションと `-d` オプションの組み合わせを使用します。この場合、30日前の日付を取得するために、次のように書き換えることができます：

```bash
rm -rf ./FILE/$(date -D %Y%m%d -d "$(date +%Y%m%d) - 30 days")*
rm -rf ./DSC/$(date -D %Y%m%d -d "$(date +%Y%m%d) - 30 days")*
```

このコマンドは、現在の日付をフォーマット `%Y%m%d` で取得し、その日付から30日前を計算しています。計算された日付は、`rm -rf` コマンドで使用され、指定されたディレクトリ内のファイルを削除します。

Alpine Linux の `date` コマンドは GNU date コマンドとは異なるため、日付計算に関してはこのような書き換えが必要になります。